### PR TITLE
Fix for dnssec

### DIFF
--- a/lib/site-inspector/dns.rb
+++ b/lib/site-inspector/dns.rb
@@ -15,7 +15,7 @@ class SiteInspector
   end
 
   def dnssec?
-    @dnssec ||= dns.any? { |record| record.type == "DNSKEY" }
+    @dnssec ||= query("DNSKEY").count != 0
   end
 
   def ipv6?


### PR DESCRIPTION
Follow up to https://github.com/benbalter/site-inspector-ruby/pull/14, fix for DNSEC tests.

@konklone for context, ran into the same problem with IPV6. Not all DNS servers respond with the same fields when you request ANY. Depending on the server, it may not return `AAAA` or `DNSKEY` records unless explicitly asked. Although a bit slower (another DNS lookup call), this should be compatible with more DNS servers.

Alternatively, we could try to hard code a specific server (e.g., Google), but think this is less fragile.