### PR TITLE
Expose headers in CLI output, and switch to Oj for JSON encoding

### DIFF
--- a/bin/site-inspector
+++ b/bin/site-inspector
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require_relative "../lib/site-inspector"
-require "json"
+require "oj"
 
 domain = ARGV[0]
 
@@ -12,4 +12,4 @@ end
 
 details = SiteInspector.new(domain).to_hash
 
-puts JSON.pretty_generate(details)
+puts Oj.dump(details, indent: 2, :mode => :compat)

--- a/lib/site-inspector.rb
+++ b/lib/site-inspector.rb
@@ -156,7 +156,8 @@ class SiteInspector
       :content_security_policy => content_security_policy?,
       :xss_protection => xss_protection?,
       :secure_cookies => secure_cookies?,
-      :strict_transport_security => strict_transport_security?
+      :strict_transport_security => strict_transport_security?,
+      :headers => headers
     }
   end
 end

--- a/site-inspector.gemspec
+++ b/site-inspector.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency("dnsruby", "~> 1.56")
   s.add_dependency("sniffles", "~> 0.2")
   s.add_dependency("typhoeus", "~> 0.6")
+  s.add_dependency("oj", "~> 2.11")
   s.add_development_dependency("pry", "~> 0.10")
   s.add_development_dependency( "rake", "~> 10.4" )
   s.add_development_dependency( "shoulda", "~> 3.5" )

--- a/test/test_site_inspector_bin.rb
+++ b/test/test_site_inspector_bin.rb
@@ -6,6 +6,6 @@ class TestSiteInspectorBin < Minitest::Test
   end
 
   should "output the hash" do
-    assert `bundle exec site-inspector whitehouse.gov` =~ /"government": true/i
+    assert `bundle exec site-inspector whitehouse.gov` =~ /"government":true/i
   end
 end


### PR DESCRIPTION
The contents of the headers are helpful information, especially for finer grained analysis than site-inspector builds in itself. This adds a `headers` field to the JSON output of the CLI interface.

I noticed when using this that `JSON.pretty_generate`, which ships with the Ruby stdlib, chokes on Unicode characters. Some Arizonan domains have an `X-Header` header with a value of `Boost Helás Avril 1.0`, and that was causing crashes.

The problem seemed internal to the JSON stdlib, and not something I could fix by encoding the data before sending in, so this switches to Oj. Oj is my favorite JSON encoder/decoder, is insanely fast, and fixes the Unicode issue.