### PR TITLE
Adds a basic disk cache

### DIFF
--- a/lib/site-inspector.rb
+++ b/lib/site-inspector.rb
@@ -17,7 +17,11 @@ require_relative 'site-inspector/dns'
 require_relative 'site-inspector/compliance'
 require_relative 'site-inspector/headers'
 
-Typhoeus::Config.cache = SiteInspectorCache.new
+if ENV['CACHE']
+  Typhoeus::Config.cache = SiteInspectorDiskCache.new(ENV['CACHE'])
+else
+  Typhoeus::Config.cache = SiteInspectorCache.new
+end
 
 class SiteInspector
 

--- a/lib/site-inspector/cache.rb
+++ b/lib/site-inspector/cache.rb
@@ -11,3 +11,37 @@ class SiteInspectorCache
     @memory[request] = response
   end
 end
+
+class SiteInspectorDiskCache
+  def initialize(dir = nil)
+    @dir = dir
+    @memory = {}
+  end
+
+  def path(request)
+    File.join(@dir, request.cache_key)
+  end
+
+  def fetch(request)
+    puts request.cache_key
+    if File.exist?(path(request))
+      Marshal.load(File.read(path(request)))
+    end
+  end
+
+  def store(request, response)
+    puts request.cache_key
+    File.open(File.join(@dir, request.cache_key), "w") do |f|
+      f.write Marshal.dump(response)
+    end
+  end
+
+  def get(request)
+    @memory[request] || fetch(request)
+  end
+
+  def set(request, response)
+    store(request, response)
+    @memory[request] = response
+  end
+end

--- a/lib/site-inspector/cache.rb
+++ b/lib/site-inspector/cache.rb
@@ -23,14 +23,12 @@ class SiteInspectorDiskCache
   end
 
   def fetch(request)
-    puts request.cache_key
     if File.exist?(path(request))
       Marshal.load(File.read(path(request)))
     end
   end
 
   def store(request, response)
-    puts request.cache_key
     File.open(File.join(@dir, request.cache_key), "w") do |f|
       f.write Marshal.dump(response)
     end


### PR DESCRIPTION
This allows the caller to specify a `CACHE` environment variable that points to a directory. If specified, Typheous will use a disk cache that will persist across individual executions of `site-inspector`.

This drastically speeds up repeated and batch use of `site-inspector`.