### PR TITLE
Be resilient to corrupted cache files

### DIFF
--- a/lib/site-inspector/cache.rb
+++ b/lib/site-inspector/cache.rb
@@ -24,8 +24,9 @@ class SiteInspectorDiskCache
 
   def fetch(request)
     if File.exist?(path(request))
+      contents = File.read(path(request))
       begin
-        return Marshal.load(File.read(path(request)))
+        return Marshal.load(contents)
       rescue ArgumentError
         FileUtils.rm(path(request))
         return nil

--- a/lib/site-inspector/cache.rb
+++ b/lib/site-inspector/cache.rb
@@ -24,7 +24,12 @@ class SiteInspectorDiskCache
 
   def fetch(request)
     if File.exist?(path(request))
-      Marshal.load(File.read(path(request)))
+      begin
+        return Marshal.load(File.read(path(request)))
+      rescue ArgumentError
+        FileUtils.rm(path(request))
+        return nil
+      end
     end
   end
 

--- a/lib/site-inspector/cache.rb
+++ b/lib/site-inspector/cache.rb
@@ -26,10 +26,10 @@ class SiteInspectorDiskCache
     if File.exist?(path(request))
       contents = File.read(path(request))
       begin
-        return Marshal.load(contents)
+        Marshal.load(contents)
       rescue ArgumentError
         FileUtils.rm(path(request))
-        return nil
+        nil
       end
     end
   end


### PR DESCRIPTION
If a cache file was left in a corrupted state (which causes an `ArgumentError` during unmarshal) then detect it, delete it, and move on as if it was uncached.