### PR TITLE
Adds a quick cache replacement function

### DIFF
--- a/lib/site-inspector.rb
+++ b/lib/site-inspector.rb
@@ -18,7 +18,7 @@ require_relative 'site-inspector/compliance'
 require_relative 'site-inspector/headers'
 
 if ENV['CACHE']
-  Typhoeus::Config.cache = SiteInspectorDiskCache.new(ENV['CACHE'])
+  Typhoeus::Config.cache = SiteInspectorDiskCache.new(ENV['CACHE'], ENV['CACHE_REPLACE'])
 else
   Typhoeus::Config.cache = SiteInspectorCache.new
 end

--- a/lib/site-inspector/cache.rb
+++ b/lib/site-inspector/cache.rb
@@ -13,9 +13,10 @@ class SiteInspectorCache
 end
 
 class SiteInspectorDiskCache
-  def initialize(dir = nil)
+  def initialize(dir = nil, replace = false)
     @dir = dir
     @memory = {}
+    @replace = replace
   end
 
   def path(request)
@@ -24,12 +25,19 @@ class SiteInspectorDiskCache
 
   def fetch(request)
     if File.exist?(path(request))
-      contents = File.read(path(request))
-      begin
-        Marshal.load(contents)
-      rescue ArgumentError
+
+      if @replace
+        puts "Deleting cache file."
         FileUtils.rm(path(request))
         nil
+      else
+        contents = File.read(path(request))
+        begin
+          Marshal.load(contents)
+        rescue ArgumentError
+          FileUtils.rm(path(request))
+          nil
+        end
       end
     end
   end

--- a/lib/site-inspector/cache.rb
+++ b/lib/site-inspector/cache.rb
@@ -27,7 +27,6 @@ class SiteInspectorDiskCache
     if File.exist?(path(request))
 
       if @replace
-        puts "Deleting cache file."
         FileUtils.rm(path(request))
         nil
       else


### PR DESCRIPTION
By setting `$CACHE_REPLACE` to anything, it causes the cache for any accessed domain to be ignored, deleted, and replaced with the subsequent results.

This is meant to be an easy way to invalidate the cache for a particular domain name, without needing to bend over backwards to figure out which hash-named file in the cache corresponds to individual HTTP requests.